### PR TITLE
Removing unnecessary dependencies

### DIFF
--- a/ethpm.json
+++ b/ethpm.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizable",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An authorizable smart contract",
   "devDependencies": {},
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,8 @@
   "author": "Francesco Sullo <francesco@sullo.co>",
   "license": "MIT",
   "dependencies": {},
-  "devDependencies": {
-    "truffle-hdwallet-provider": "0.0.3"
-  },
+  "devDependencies": {},
   "scripts": {
-    "publish": "source ../ifo-ropsten.env && truffle publish"
+    "publish": "source ../../ifo-ropsten.env && truffle publish"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizable",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An authorizable smart contract",
   "repository": {
     "type": "git",

--- a/truffle.js
+++ b/truffle.js
@@ -1,19 +1,9 @@
-const HDWalletProvider = require("truffle-hdwallet-provider")
-const mnemonic = process.env.MNEMONIC
-const infuraUrl = process.env.INFURA_URL
-
 module.exports = {
   networks: {
     development: {
       host: "localhost",
       port: 8545,
       network_id: "*"
-    },
-    ropsten: {
-      provider: function() {
-        return new HDWalletProvider(mnemonic, infuraUrl)
-      },
-      network_id: 3
     }
   },
   solc: {


### PR DESCRIPTION
This removes in truffle.js the procedure to deploy to ropsten using `truffle-hdwallet-provider` because not necessary in the context of an extendable contract.