### PR TITLE
Removing useless uint >=0, any uint is >=0

### DIFF
--- a/contracts/Authorizable.sol
+++ b/contracts/Authorizable.sol
@@ -172,7 +172,7 @@ contract Authorizable is Ownable {
    */
   function __authorize(address _address, uint _level) internal {
     require(_address != address(0));
-    require(_level >= 0 && _level <= maxLevel);
+    require(_level <= maxLevel);
 
     uint i;
     if (_level > 0 && authorized[_address] != _level) {

--- a/flattened/Authorizable.sol
+++ b/flattened/Authorizable.sol
@@ -214,7 +214,7 @@ contract Authorizable is Ownable {
    */
   function __authorize(address _address, uint _level) internal {
     require(_address != address(0));
-    require(_level >= 0 && _level <= maxLevel);
+    require(_level <= maxLevel);
 
     uint i;
     if (_level > 0 && authorized[_address] != _level) {


### PR DESCRIPTION
Removing useless uint >=0, because any uint is >=0