### PR TITLE
Compatible with 0.4.23

### DIFF
--- a/contracts/Authorizable.sol
+++ b/contracts/Authorizable.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.23;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import './Ownable.sol';
 
 /**
  * @title Authorizable
@@ -158,7 +158,7 @@ contract Authorizable /** 0.1.9 */ is Ownable {
    *      wallets the operation must be repeated.
    */
   function deAuthorizeAll() onlyOwner external {
-    for (uint i = 0; i < __authorized.length && msg.gas > 33e3; i++) {
+    for (uint i = 0; i < __authorized.length && gasleft() > 33e3; i++) {
       if (__authorized[i] != address(0)) {
         __authorize(__authorized[i], 0);
       }
@@ -170,7 +170,7 @@ contract Authorizable /** 0.1.9 */ is Ownable {
    * @param _level The level of authorization
    */
   function deAuthorizeAllAtLevel(uint _level) onlyAuthorizer external {
-    for (uint i = 0; i < __authorized.length && msg.gas > 33e3; i++) {
+    for (uint i = 0; i < __authorized.length && gasleft() > 33e3; i++) {
       if (__authorized[i] != address(0) && authorized[__authorized[i]] == _level) {
         __authorize(__authorized[i], 0);
       }

--- a/contracts/AuthorizableLite.sol
+++ b/contracts/AuthorizableLite.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.23;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import './Ownable.sol';
 
 /**
  * @title AuthorizableLite
@@ -127,14 +127,14 @@ contract AuthorizableLite /** 0.1.9 */ is Ownable {
           }
           totalAuthorized++;
         }
-        AuthorizedAdded(msg.sender, _address, _level);
+        emit AuthorizedAdded(msg.sender, _address, _level);
         authorized[_address] = _level;
     } else if (_level == 0 && authorized[_address] > 0) {
       for (i = 0; i < __authorized.length; i++) {
         if (__authorized[i] == _address) {
           __authorized[i] = address(0);
           totalAuthorized--;
-          AuthorizedRemoved(msg.sender, _address);
+          emit AuthorizedRemoved(msg.sender, _address);
           delete authorized[_address];
           break;
         }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.4.23;
+
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+  address public owner;
+
+
+  event OwnershipRenounced(address indexed previousOwner);
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
+
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    require(newOwner != address(0));
+    emit OwnershipTransferred(owner, newOwner);
+    owner = newOwner;
+  }
+
+  /**
+   * @dev Allows the current owner to relinquish control of the contract.
+   */
+  function renounceOwnership() public onlyOwner {
+    emit OwnershipRenounced(owner);
+    owner = address(0);
+  }
+}

--- a/flattened/Authorizable.sol
+++ b/flattened/Authorizable.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
-// File: openzeppelin-solidity/contracts/ownership/Ownable.sol
+// File: contracts/Ownable.sol
 
 /**
  * @title Ownable
@@ -11,14 +11,18 @@ contract Ownable {
   address public owner;
 
 
-  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+  event OwnershipRenounced(address indexed previousOwner);
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
 
 
   /**
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
    * account.
    */
-  function Ownable() public {
+  constructor() public {
     owner = msg.sender;
   }
 
@@ -40,6 +44,13 @@ contract Ownable {
     owner = newOwner;
   }
 
+  /**
+   * @dev Allows the current owner to relinquish control of the contract.
+   */
+  function renounceOwnership() public onlyOwner {
+    emit OwnershipRenounced(owner);
+    owner = address(0);
+  }
 }
 
 // File: contracts/Authorizable.sol
@@ -200,7 +211,7 @@ contract Authorizable /** 0.1.9 */ is Ownable {
    *      wallets the operation must be repeated.
    */
   function deAuthorizeAll() onlyOwner external {
-    for (uint i = 0; i < __authorized.length && msg.gas > 33e3; i++) {
+    for (uint i = 0; i < __authorized.length && gasleft() > 33e3; i++) {
       if (__authorized[i] != address(0)) {
         __authorize(__authorized[i], 0);
       }
@@ -212,7 +223,7 @@ contract Authorizable /** 0.1.9 */ is Ownable {
    * @param _level The level of authorization
    */
   function deAuthorizeAllAtLevel(uint _level) onlyAuthorizer external {
-    for (uint i = 0; i < __authorized.length && msg.gas > 33e3; i++) {
+    for (uint i = 0; i < __authorized.length && gasleft() > 33e3; i++) {
       if (__authorized[i] != address(0) && authorized[__authorized[i]] == _level) {
         __authorize(__authorized[i], 0);
       }

--- a/flattened/AuthorizableLite.sol
+++ b/flattened/AuthorizableLite.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
-// File: openzeppelin-solidity/contracts/ownership/Ownable.sol
+// File: contracts/Ownable.sol
 
 /**
  * @title Ownable
@@ -11,14 +11,18 @@ contract Ownable {
   address public owner;
 
 
-  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+  event OwnershipRenounced(address indexed previousOwner);
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
 
 
   /**
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
    * account.
    */
-  function Ownable() public {
+  constructor() public {
     owner = msg.sender;
   }
 
@@ -40,6 +44,13 @@ contract Ownable {
     owner = newOwner;
   }
 
+  /**
+   * @dev Allows the current owner to relinquish control of the contract.
+   */
+  function renounceOwnership() public onlyOwner {
+    emit OwnershipRenounced(owner);
+    owner = address(0);
+  }
 }
 
 // File: contracts/AuthorizableLite.sol
@@ -169,14 +180,14 @@ contract AuthorizableLite /** 0.1.9 */ is Ownable {
           }
           totalAuthorized++;
         }
-        AuthorizedAdded(msg.sender, _address, _level);
+        emit AuthorizedAdded(msg.sender, _address, _level);
         authorized[_address] = _level;
     } else if (_level == 0 && authorized[_address] > 0) {
       for (i = 0; i < __authorized.length; i++) {
         if (__authorized[i] == _address) {
           __authorized[i] = address(0);
           totalAuthorized--;
-          AuthorizedRemoved(msg.sender, _address);
+          emit AuthorizedRemoved(msg.sender, _address);
           delete authorized[_address];
           break;
         }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "truffle-flattener": "^1.2.5",
-    "openzeppelin-solidity": "^1.9.0"
+    "truffle-flattener": "^1.2.5"
   },
   "scripts": {
     "flatten": "truffle-flattener contracts/Authorizable.sol > flattened/Authorizable.sol && truffle-flattener contracts/AuthorizableLite.sol > flattened/AuthorizableLite.sol",


### PR DESCRIPTION
This fixes an issue with pragma 0.4.23 due to `openzeppelin-solidity` which for some reasons loads a wrong `Ownabl.sol` using `npm i openzeppelin-solidity`