### PR TITLE
Fixing issues with new compiler

### DIFF
--- a/contracts/AuthorizableLite.sol
+++ b/contracts/AuthorizableLite.sol
@@ -10,166 +10,166 @@ import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
 contract AuthorizableLite /** 0.1.9 */ is Ownable {
 
-  uint public totalAuthorized;
+    uint public totalAuthorized;
 
-  mapping(address => uint) public authorized;
-  address[] internal __authorized;
+    mapping(address => uint) public authorized;
+    address[] internal __authorized;
 
-  event AuthorizedAdded(address _authorizer, address _authorized, uint _level);
+    event AuthorizedAdded(address _authorizer, address _authorized, uint _level);
 
-  event AuthorizedRemoved(address _authorizer, address _authorized);
+    event AuthorizedRemoved(address _authorizer, address _authorized);
 
-  uint public maxLevel = 64;
-  uint public authorizerLevel = 56;
+    uint public maxLevel = 64;
+    uint public authorizerLevel = 56;
 
-  /**
-   * @dev Set the range of levels accepted by the contract
-   * @param _maxLevel The max level acceptable
-   * @param _authorizerLevel The minimum level to qualify a wallet as authorizer
-   */
-  function setLevels(uint _maxLevel, uint _authorizerLevel) external onlyOwner {
-    // this must be called before authorizing any address
-    require(totalAuthorized == 0);
-    require(_maxLevel > 0 && _authorizerLevel > 0);
-    require(_maxLevel >= _authorizerLevel);
+    /**
+     * @dev Set the range of levels accepted by the contract
+     * @param _maxLevel The max level acceptable
+     * @param _authorizerLevel The minimum level to qualify a wallet as authorizer
+     */
+    function setLevels(uint _maxLevel, uint _authorizerLevel) external onlyOwner {
+        // this must be called before authorizing any address
+        require(totalAuthorized == 0);
+        require(_maxLevel > 0 && _authorizerLevel > 0);
+        require(_maxLevel >= _authorizerLevel);
 
-    maxLevel = _maxLevel;
-    authorizerLevel = _authorizerLevel;
-  }
+        maxLevel = _maxLevel;
+        authorizerLevel = _authorizerLevel;
+    }
 
-  /**
-   * @dev Throws if called by any account which is not authorized.
-   */
-  modifier onlyAuthorized() {
-    require(authorized[msg.sender] > 0);
-    _;
-  }
+    /**
+     * @dev Throws if called by any account which is not authorized.
+     */
+    modifier onlyAuthorized() {
+        require(authorized[msg.sender] > 0);
+        _;
+    }
 
-  /**
-   * @dev Throws if called by any account which is not
-   *      authorized at a specific level.
-   * @param _level Level required
-   */
-  modifier onlyAuthorizedAtLevel(uint _level) {
-    require(authorized[msg.sender] == _level);
-    _;
-  }
+    /**
+     * @dev Throws if called by any account which is not
+     *      authorized at a specific level.
+     * @param _level Level required
+     */
+    modifier onlyAuthorizedAtLevel(uint _level) {
+        require(authorized[msg.sender] == _level);
+        _;
+    }
 
-  /**
-    * @dev same modifiers above, but including the owner
-    */
-  modifier onlyOwnerOrAuthorized() {
-    require(msg.sender == owner || authorized[msg.sender] > 0);
-    _;
-  }
+    /**
+      * @dev same modifiers above, but including the owner
+      */
+    modifier onlyOwnerOrAuthorized() {
+        require(msg.sender == owner || authorized[msg.sender] > 0);
+        _;
+    }
 
-  modifier onlyOwnerOrAuthorizedAtLevel(uint _level) {
-    require(msg.sender == owner || authorized[msg.sender] == _level);
-    _;
-  }
+    modifier onlyOwnerOrAuthorizedAtLevel(uint _level) {
+        require(msg.sender == owner || authorized[msg.sender] == _level);
+        _;
+    }
 
-  /**
-    * @dev Throws if called by anyone who is not an authorizer.
-    */
-  modifier onlyAuthorizer() {
-    require(msg.sender == owner || authorized[msg.sender] >= authorizerLevel);
-    _;
-  }
+    /**
+      * @dev Throws if called by anyone who is not an authorizer.
+      */
+    modifier onlyAuthorizer() {
+        require(msg.sender == owner || authorized[msg.sender] >= authorizerLevel);
+        _;
+    }
 
 
-  /**
-    * @dev Allows to add a new authorized address, or remove it, setting _level to 0
-    * @param _address The address to be authorized
-    * @param _level The level of authorization
-    */
-  function authorize(address _address, uint _level) onlyAuthorizer external {
-    __authorize(_address, _level);
-  }
+    /**
+      * @dev Allows to add a new authorized address, or remove it, setting _level to 0
+      * @param _address The address to be authorized
+      * @param _level The level of authorization
+      */
+    function authorize(address _address, uint _level) onlyAuthorizer external {
+        __authorize(_address, _level);
+    }
 
-  /**
-   * @dev Allows an authorized to de-authorize itself.
-   */
-  function deAuthorize() onlyAuthorized external {
-    __authorize(msg.sender, 0);
-  }
+    /**
+     * @dev Allows an authorized to de-authorize itself.
+     */
+    function deAuthorize() onlyAuthorized external {
+        __authorize(msg.sender, 0);
+    }
 
-  /**
-   * @dev Performs the actual authorization/de-authorization
-   *      If there's no change, it doesn't emit any event, to reduce gas usage.
-   * @param _address The address to be authorized
-   * @param _level The level of authorization. 0 to remove it.
-   */
-  function __authorize(address _address, uint _level) internal {
-    require(_address != address(0));
-    require(_level <= maxLevel);
+    /**
+     * @dev Performs the actual authorization/de-authorization
+     *      If there's no change, it doesn't emit any event, to reduce gas usage.
+     * @param _address The address to be authorized
+     * @param _level The level of authorization. 0 to remove it.
+     */
+    function __authorize(address _address, uint _level) internal {
+        require(_address != address(0));
+        require(_level <= maxLevel);
 
-    uint i;
-    if (_level > 0 && authorized[_address] != _level) {
-        bool alreadyIndexed = false;
-        for (i = 0; i < __authorized.length; i++) {
-          if (__authorized[i] == _address) {
-            alreadyIndexed = true;
-            break;
-          }
-        }
-        if (alreadyIndexed == false) {
-          bool emptyFound = false;
-          // before we try to reuse an empty element of the array
-          for (i = 0; i < __authorized.length; i++) {
-            if (__authorized[i] == 0) {
-              __authorized[i] = _address;
-              emptyFound = true;
-              break;
+        uint i;
+        if (_level > 0 && authorized[_address] != _level) {
+            bool alreadyIndexed = false;
+            for (i = 0; i < __authorized.length; i++) {
+                if (__authorized[i] == _address) {
+                    alreadyIndexed = true;
+                    break;
+                }
             }
-          }
-          if (emptyFound == false) {
-            __authorized.push(_address);
-          }
-          totalAuthorized++;
+            if (alreadyIndexed == false) {
+                bool emptyFound = false;
+                // before we try to reuse an empty element of the array
+                for (i = 0; i < __authorized.length; i++) {
+                    if (__authorized[i] == 0) {
+                        __authorized[i] = _address;
+                        emptyFound = true;
+                        break;
+                    }
+                }
+                if (emptyFound == false) {
+                    __authorized.push(_address);
+                }
+                totalAuthorized++;
+            }
+            AuthorizedAdded(msg.sender, _address, _level);
+            authorized[_address] = _level;
+        } else if (_level == 0 && authorized[_address] > 0) {
+            for (i = 0; i < __authorized.length; i++) {
+                if (__authorized[i] == _address) {
+                    __authorized[i] = address(0);
+                    totalAuthorized--;
+                    AuthorizedRemoved(msg.sender, _address);
+                    delete authorized[_address];
+                    break;
+                }
+            }
         }
-        AuthorizedAdded(msg.sender, _address, _level);
-        authorized[_address] = _level;
-    } else if (_level == 0 && authorized[_address] > 0) {
-      for (i = 0; i < __authorized.length; i++) {
-        if (__authorized[i] == _address) {
-          __authorized[i] = address(0);
-          totalAuthorized--;
-          AuthorizedRemoved(msg.sender, _address);
-          delete authorized[_address];
-          break;
+    }
+
+    /**
+     * @dev Check is a level is included in an array of levels. Used by modifiers
+     * @param _level Level to be checked
+     * @param _levels Array of required levels
+     */
+    function __hasLevel(uint _level, uint[] _levels) internal pure returns (bool) {
+        bool has = false;
+        for (uint i; i < _levels.length; i++) {
+            if (_level == _levels[i]) {
+                has = true;
+                break;
+            }
         }
-      }
+        return has;
     }
-  }
 
-  /**
-   * @dev Check is a level is included in an array of levels. Used by modifiers
-   * @param _level Level to be checked
-   * @param _levels Array of required levels
-   */
-  function __hasLevel(uint _level, uint[] _levels) internal pure returns (bool) {
-    bool has = false;
-    for (uint i; i < _levels.length; i++) {
-      if (_level == _levels[i]) {
-        has = true;
-        break;
-      }
+    /**
+     * @dev Allows a wallet to check if it is authorized
+     */
+    function amIAuthorized() external constant returns (bool) {
+        return authorized[msg.sender] > 0;
     }
-    return has;
-  }
 
-  /**
-   * @dev Allows a wallet to check if it is authorized
-   */
-  function amIAuthorized() external constant returns (bool) {
-    return authorized[msg.sender] > 0;
-  }
-
-  /**
-   * @dev Allows any authorizer to get the list of the authorized wallets
-   */
-  function getAuthorized() external onlyAuthorizer constant returns (address[]) {
-    return __authorized;
-  }
+    /**
+     * @dev Allows any authorizer to get the list of the authorized wallets
+     */
+    function getAuthorized() external onlyAuthorizer constant returns (address[]) {
+        return __authorized;
+    }
 
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.4.23;
 
 contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
+  constructor() public {
+    owner = msg.sender;
   }
 
-  function Migrations() public {
-    owner = msg.sender;
+  modifier restricted() {
+    if (msg.sender == owner) _;
   }
 
   function setCompleted(uint completed) public restricted {

--- a/flattened/Authorizable.sol
+++ b/flattened/Authorizable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.18;
 
 // File: openzeppelin-solidity/contracts/ownership/Ownable.sol
 
@@ -36,7 +36,7 @@ contract Ownable {
    */
   function transferOwnership(address newOwner) public onlyOwner {
     require(newOwner != address(0));
-    emit OwnershipTransferred(owner, newOwner);
+    OwnershipTransferred(owner, newOwner);
     owner = newOwner;
   }
 

--- a/flattened/AuthorizableLite.sol
+++ b/flattened/AuthorizableLite.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.18;
 
 // File: openzeppelin-solidity/contracts/ownership/Ownable.sol
 
@@ -36,7 +36,7 @@ contract Ownable {
    */
   function transferOwnership(address newOwner) public onlyOwner {
     require(newOwner != address(0));
-    emit OwnershipTransferred(owner, newOwner);
+    OwnershipTransferred(owner, newOwner);
     owner = newOwner;
   }
 
@@ -52,166 +52,166 @@ contract Ownable {
 
 contract AuthorizableLite /** 0.1.9 */ is Ownable {
 
-  uint public totalAuthorized;
+    uint public totalAuthorized;
 
-  mapping(address => uint) public authorized;
-  address[] internal __authorized;
+    mapping(address => uint) public authorized;
+    address[] internal __authorized;
 
-  event AuthorizedAdded(address _authorizer, address _authorized, uint _level);
+    event AuthorizedAdded(address _authorizer, address _authorized, uint _level);
 
-  event AuthorizedRemoved(address _authorizer, address _authorized);
+    event AuthorizedRemoved(address _authorizer, address _authorized);
 
-  uint public maxLevel = 64;
-  uint public authorizerLevel = 56;
+    uint public maxLevel = 64;
+    uint public authorizerLevel = 56;
 
-  /**
-   * @dev Set the range of levels accepted by the contract
-   * @param _maxLevel The max level acceptable
-   * @param _authorizerLevel The minimum level to qualify a wallet as authorizer
-   */
-  function setLevels(uint _maxLevel, uint _authorizerLevel) external onlyOwner {
-    // this must be called before authorizing any address
-    require(totalAuthorized == 0);
-    require(_maxLevel > 0 && _authorizerLevel > 0);
-    require(_maxLevel >= _authorizerLevel);
+    /**
+     * @dev Set the range of levels accepted by the contract
+     * @param _maxLevel The max level acceptable
+     * @param _authorizerLevel The minimum level to qualify a wallet as authorizer
+     */
+    function setLevels(uint _maxLevel, uint _authorizerLevel) external onlyOwner {
+        // this must be called before authorizing any address
+        require(totalAuthorized == 0);
+        require(_maxLevel > 0 && _authorizerLevel > 0);
+        require(_maxLevel >= _authorizerLevel);
 
-    maxLevel = _maxLevel;
-    authorizerLevel = _authorizerLevel;
-  }
+        maxLevel = _maxLevel;
+        authorizerLevel = _authorizerLevel;
+    }
 
-  /**
-   * @dev Throws if called by any account which is not authorized.
-   */
-  modifier onlyAuthorized() {
-    require(authorized[msg.sender] > 0);
-    _;
-  }
+    /**
+     * @dev Throws if called by any account which is not authorized.
+     */
+    modifier onlyAuthorized() {
+        require(authorized[msg.sender] > 0);
+        _;
+    }
 
-  /**
-   * @dev Throws if called by any account which is not
-   *      authorized at a specific level.
-   * @param _level Level required
-   */
-  modifier onlyAuthorizedAtLevel(uint _level) {
-    require(authorized[msg.sender] == _level);
-    _;
-  }
+    /**
+     * @dev Throws if called by any account which is not
+     *      authorized at a specific level.
+     * @param _level Level required
+     */
+    modifier onlyAuthorizedAtLevel(uint _level) {
+        require(authorized[msg.sender] == _level);
+        _;
+    }
 
-  /**
-    * @dev same modifiers above, but including the owner
-    */
-  modifier onlyOwnerOrAuthorized() {
-    require(msg.sender == owner || authorized[msg.sender] > 0);
-    _;
-  }
+    /**
+      * @dev same modifiers above, but including the owner
+      */
+    modifier onlyOwnerOrAuthorized() {
+        require(msg.sender == owner || authorized[msg.sender] > 0);
+        _;
+    }
 
-  modifier onlyOwnerOrAuthorizedAtLevel(uint _level) {
-    require(msg.sender == owner || authorized[msg.sender] == _level);
-    _;
-  }
+    modifier onlyOwnerOrAuthorizedAtLevel(uint _level) {
+        require(msg.sender == owner || authorized[msg.sender] == _level);
+        _;
+    }
 
-  /**
-    * @dev Throws if called by anyone who is not an authorizer.
-    */
-  modifier onlyAuthorizer() {
-    require(msg.sender == owner || authorized[msg.sender] >= authorizerLevel);
-    _;
-  }
+    /**
+      * @dev Throws if called by anyone who is not an authorizer.
+      */
+    modifier onlyAuthorizer() {
+        require(msg.sender == owner || authorized[msg.sender] >= authorizerLevel);
+        _;
+    }
 
 
-  /**
-    * @dev Allows to add a new authorized address, or remove it, setting _level to 0
-    * @param _address The address to be authorized
-    * @param _level The level of authorization
-    */
-  function authorize(address _address, uint _level) onlyAuthorizer external {
-    __authorize(_address, _level);
-  }
+    /**
+      * @dev Allows to add a new authorized address, or remove it, setting _level to 0
+      * @param _address The address to be authorized
+      * @param _level The level of authorization
+      */
+    function authorize(address _address, uint _level) onlyAuthorizer external {
+        __authorize(_address, _level);
+    }
 
-  /**
-   * @dev Allows an authorized to de-authorize itself.
-   */
-  function deAuthorize() onlyAuthorized external {
-    __authorize(msg.sender, 0);
-  }
+    /**
+     * @dev Allows an authorized to de-authorize itself.
+     */
+    function deAuthorize() onlyAuthorized external {
+        __authorize(msg.sender, 0);
+    }
 
-  /**
-   * @dev Performs the actual authorization/de-authorization
-   *      If there's no change, it doesn't emit any event, to reduce gas usage.
-   * @param _address The address to be authorized
-   * @param _level The level of authorization. 0 to remove it.
-   */
-  function __authorize(address _address, uint _level) internal {
-    require(_address != address(0));
-    require(_level <= maxLevel);
+    /**
+     * @dev Performs the actual authorization/de-authorization
+     *      If there's no change, it doesn't emit any event, to reduce gas usage.
+     * @param _address The address to be authorized
+     * @param _level The level of authorization. 0 to remove it.
+     */
+    function __authorize(address _address, uint _level) internal {
+        require(_address != address(0));
+        require(_level <= maxLevel);
 
-    uint i;
-    if (_level > 0 && authorized[_address] != _level) {
-        bool alreadyIndexed = false;
-        for (i = 0; i < __authorized.length; i++) {
-          if (__authorized[i] == _address) {
-            alreadyIndexed = true;
-            break;
-          }
-        }
-        if (alreadyIndexed == false) {
-          bool emptyFound = false;
-          // before we try to reuse an empty element of the array
-          for (i = 0; i < __authorized.length; i++) {
-            if (__authorized[i] == 0) {
-              __authorized[i] = _address;
-              emptyFound = true;
-              break;
+        uint i;
+        if (_level > 0 && authorized[_address] != _level) {
+            bool alreadyIndexed = false;
+            for (i = 0; i < __authorized.length; i++) {
+                if (__authorized[i] == _address) {
+                    alreadyIndexed = true;
+                    break;
+                }
             }
-          }
-          if (emptyFound == false) {
-            __authorized.push(_address);
-          }
-          totalAuthorized++;
+            if (alreadyIndexed == false) {
+                bool emptyFound = false;
+                // before we try to reuse an empty element of the array
+                for (i = 0; i < __authorized.length; i++) {
+                    if (__authorized[i] == 0) {
+                        __authorized[i] = _address;
+                        emptyFound = true;
+                        break;
+                    }
+                }
+                if (emptyFound == false) {
+                    __authorized.push(_address);
+                }
+                totalAuthorized++;
+            }
+            AuthorizedAdded(msg.sender, _address, _level);
+            authorized[_address] = _level;
+        } else if (_level == 0 && authorized[_address] > 0) {
+            for (i = 0; i < __authorized.length; i++) {
+                if (__authorized[i] == _address) {
+                    __authorized[i] = address(0);
+                    totalAuthorized--;
+                    AuthorizedRemoved(msg.sender, _address);
+                    delete authorized[_address];
+                    break;
+                }
+            }
         }
-        AuthorizedAdded(msg.sender, _address, _level);
-        authorized[_address] = _level;
-    } else if (_level == 0 && authorized[_address] > 0) {
-      for (i = 0; i < __authorized.length; i++) {
-        if (__authorized[i] == _address) {
-          __authorized[i] = address(0);
-          totalAuthorized--;
-          AuthorizedRemoved(msg.sender, _address);
-          delete authorized[_address];
-          break;
+    }
+
+    /**
+     * @dev Check is a level is included in an array of levels. Used by modifiers
+     * @param _level Level to be checked
+     * @param _levels Array of required levels
+     */
+    function __hasLevel(uint _level, uint[] _levels) internal pure returns (bool) {
+        bool has = false;
+        for (uint i; i < _levels.length; i++) {
+            if (_level == _levels[i]) {
+                has = true;
+                break;
+            }
         }
-      }
+        return has;
     }
-  }
 
-  /**
-   * @dev Check is a level is included in an array of levels. Used by modifiers
-   * @param _level Level to be checked
-   * @param _levels Array of required levels
-   */
-  function __hasLevel(uint _level, uint[] _levels) internal pure returns (bool) {
-    bool has = false;
-    for (uint i; i < _levels.length; i++) {
-      if (_level == _levels[i]) {
-        has = true;
-        break;
-      }
+    /**
+     * @dev Allows a wallet to check if it is authorized
+     */
+    function amIAuthorized() external constant returns (bool) {
+        return authorized[msg.sender] > 0;
     }
-    return has;
-  }
 
-  /**
-   * @dev Allows a wallet to check if it is authorized
-   */
-  function amIAuthorized() external constant returns (bool) {
-    return authorized[msg.sender] > 0;
-  }
-
-  /**
-   * @dev Allows any authorizer to get the list of the authorized wallets
-   */
-  function getAuthorized() external onlyAuthorizer constant returns (address[]) {
-    return __authorized;
-  }
+    /**
+     * @dev Allows any authorizer to get the list of the authorized wallets
+     */
+    function getAuthorized() external onlyAuthorizer constant returns (address[]) {
+        return __authorized;
+    }
 
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,3 @@
-var Authorizable = artifacts.require("./Authorizable")
 
 module.exports = function(deployer) {
-  deployer.deploy(Authorizable)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizable",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -105,6 +105,12 @@
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -119,6 +125,17 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
       "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
       "dev": true
+    },
+    "ethjs-abi": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
+      "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      }
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -400,10 +417,14 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ==",
-      "dev": true
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.8.0.tgz",
+      "integrity": "sha512-cXG3bS6piRU9C/pOGYTzpO0uA1b5OKtYAH0Pz5J+jgT0slEFkMslXnADUG96uBp/Ft8jEQTdi29J+as6KHBDsA==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^4.0.0",
+        "ethjs-abi": "^0.2.1"
+      }
     },
     "original-require": {
       "version": "1.0.1",
@@ -689,8 +710,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-          "dev": true
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         },
         "ethjs-abi": {
           "version": "0.1.8",
@@ -714,6 +734,13 @@
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+              "dev": true
+            }
           }
         }
       }
@@ -801,8 +828,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-          "dev": true
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         },
         "web3": {
           "version": "0.20.6",
@@ -815,6 +841,13 @@
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+              "dev": true
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizable",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Smart contract governance made easy",
   "repository": {
     "type": "git",
@@ -10,11 +10,11 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "openzeppelin-solidity": "1.9.0",
+    "openzeppelin-solidity": "^1.8.0",
     "truffle-flattener": "^1.2.5"
   },
   "scripts": {
-    "flatten": "truffle-flattener contracts/Authorizable.sol > flattened/Authorizable.sol && truffle-flattener contracts/AuthorizableLite.sol > flattened/AuthorizableLite.sol",
+    "flatten": "scripts/flatten.sh",
     "new-version": "scripts/new-version.sh"
   }
 }

--- a/scripts/flatten.sh
+++ b/scripts/flatten.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+contracts=(
+"Authorizable"
+"AuthorizableLite"
+)
+
+for c in "${contracts[@]}"
+do
+  truffle-flattener "contracts/$c.sol" > "flattened/$c.sol"
+done


### PR DESCRIPTION
This version fixes an issue introduced trying to use solc 0.4.23 and zeppelin-solidity 1.9.0.
Here we reverse to solc 0.4.18 and zeppelin-solidity 1.8.0